### PR TITLE
Fixed duplicated BCb reference to BCr.

### DIFF
--- a/Adafruit_TLC59711.cpp
+++ b/Adafruit_TLC59711.cpp
@@ -71,7 +71,7 @@ void Adafruit_TLC59711::write(void) {
   command |= 0x16;
 
   command <<= 7;
-  command |= BCb;
+  command |= BCr;
 
   command <<= 7;
   command |= BCg;


### PR DESCRIPTION
Given the BCr = BCg = BCb = 0x7F (line 27) this doesn't make a difference, but it's still fixing an error that can be important if someone uses this library as a base for future development.
