### PR TITLE
Updating hardware SPI codepath.

### DIFF
--- a/Adafruit_TLC59711.cpp
+++ b/Adafruit_TLC59711.cpp
@@ -34,9 +34,6 @@ Adafruit_TLC59711::Adafruit_TLC59711(uint8_t n) {
   _clk = -1;
   _dat = -1;
 
-  SPI.setBitOrder(MSBFIRST);
-  SPI.setClockDivider(SPI_CLOCK_DIV8);
-  SPI.setDataMode(SPI_MODE0);
   BCr = BCg = BCb = 0x7F;
 
   pwmbuffer = (uint16_t *)calloc(2, 12*n);
@@ -80,6 +77,11 @@ void Adafruit_TLC59711::write(void) {
   command |= BCb;
 
   cli();
+  
+  if (_clk < 0) {
+    SPI.beginTransaction(SPISettings(500000, MSBFIRST, SPI_MODE0));
+  }
+  
   for (uint8_t n=0; n<numdrivers; n++) {
     spiwriteMSB(command >> 24);
     spiwriteMSB(command >> 16);
@@ -94,10 +96,13 @@ void Adafruit_TLC59711::write(void) {
     }
   }
 
-  if (_clk >= 0)
+  if (_clk >= 0) {
     delayMicroseconds(200);
-  else
+  } else {
+    SPI.endTransaction();
     delayMicroseconds(2);
+  }
+
   sei();
 }
 
@@ -122,8 +127,6 @@ boolean Adafruit_TLC59711::begin() {
   if (_clk >= 0) {
     pinMode(_clk, OUTPUT);
     pinMode(_dat, OUTPUT);
-  } else {
-    SPI.begin();
   }
   return true;
 }


### PR DESCRIPTION
There is a flickering issue when SPI data is driven above 0.5Mhz (limited testing, this value works on 3V/12Mhz and 5V/16Mhz Pro Trinkets, I do not have access to others or advanced circuits to test fine grained bandwidth limits) with low brightness levels, causing the internal TLC59711 chip to propagate some bits from bright LEDs to dim LEDs during large brightness changes, particularly visible with chained chips: Set all LEDs to 0 on one chip, and all to 0 on a second chip, then vary one value on any chip and the matching LED on all chips will flicker.

I hereby assign all Copyright on this code patch to AdaFruit, go integrate this so everyone's happier with this wonderful LED control board. :D
