### PR TITLE
Fix setPWM not working above 255 channels

### DIFF
--- a/Adafruit_TLC59711.cpp
+++ b/Adafruit_TLC59711.cpp
@@ -116,7 +116,7 @@ void Adafruit_TLC59711::write() {
  *  @param  pwm
  *          pwm value
  */
-void Adafruit_TLC59711::setPWM(uint8_t chan, uint16_t pwm) {
+void Adafruit_TLC59711::setPWM(uint16_t chan, uint16_t pwm) {
   if (chan > 12 * numdrivers)
     return;
   pwmbuffer[chan] = pwm;

--- a/Adafruit_TLC59711.h
+++ b/Adafruit_TLC59711.h
@@ -36,7 +36,7 @@ public:
 
   bool begin();
 
-  void setPWM(uint8_t chan, uint16_t pwm);
+  void setPWM(uint16_t chan, uint16_t pwm);
   void setLED(uint8_t lednum, uint16_t r, uint16_t g, uint16_t b);
   void getLED(uint8_t lednum, uint16_t &r, uint16_t &g, uint16_t &b);
   void write();


### PR DESCRIPTION
Channels above 255 are not working. Wraps back to 0.

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.
Uses one more byte when calling setPWM() function.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.
Cannot use channels above 65,535

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.
Change was tested over various projects

