### PR TITLE
fix #24 - change datatype in `setLED` to allow for more than 63 TLC59711 devices

### DIFF
--- a/Adafruit_TLC59711.cpp
+++ b/Adafruit_TLC59711.cpp
@@ -133,7 +133,7 @@ void Adafruit_TLC59711::setPWM(uint16_t chan, uint16_t pwm) {
  *  @param b
  *          blue value
  */
-void Adafruit_TLC59711::setLED(uint8_t lednum, uint16_t r, uint16_t g,
+void Adafruit_TLC59711::setLED(uint16_t lednum, uint16_t r, uint16_t g,
                                uint16_t b) {
   setPWM(lednum * 3, r);
   setPWM(lednum * 3 + 1, g);
@@ -151,7 +151,7 @@ void Adafruit_TLC59711::setLED(uint8_t lednum, uint16_t r, uint16_t g,
  *  @param b
  *          blue value
  */
-void Adafruit_TLC59711::getLED(uint8_t lednum, uint16_t &r, uint16_t &g,
+void Adafruit_TLC59711::getLED(uint16_t lednum, uint16_t &r, uint16_t &g,
                                uint16_t &b) {
   r = pwmbuffer[lednum * 3];
   g = pwmbuffer[lednum * 3 + 1];

--- a/Adafruit_TLC59711.h
+++ b/Adafruit_TLC59711.h
@@ -37,8 +37,8 @@ public:
   bool begin();
 
   void setPWM(uint16_t chan, uint16_t pwm);
-  void setLED(uint8_t lednum, uint16_t r, uint16_t g, uint16_t b);
-  void getLED(uint8_t lednum, uint16_t &r, uint16_t &g, uint16_t &b);
+  void setLED(uint16_t lednum, uint16_t r, uint16_t g, uint16_t b);
+  void getLED(uint16_t lednum, uint16_t &r, uint16_t &g, uint16_t &b);
   void write();
   void setBrightness(uint8_t bcr, uint8_t bcg, uint8_t bcb);
   void simpleSetBrightness(uint8_t BC);
@@ -47,7 +47,7 @@ private:
   uint16_t *pwmbuffer = NULL;
 
   uint8_t BCr = 0, BCg = 0, BCb = 0;
-  int8_t numdrivers = 0;
+  uint8_t numdrivers = 0;
   Adafruit_SPIDevice *_spi_dev = NULL;
 };
 


### PR DESCRIPTION
fixes #24 
→ changed the datatype in `setLED` from `uint8_t`  to `uint16_t` to allow for more than 255 leds (=more than 63 TLCs)

